### PR TITLE
Support json url to filler

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 )
 
 const (
@@ -14,16 +15,17 @@ const (
 )
 
 var (
-	dataFlag        *string
-	tokenFlag       *string
-	environmentFlag *string
-	nameFlag        *string
-	descriptionFlag *string
-	typeContentFlag *string
-	monthFlag       *string
-	yearFlag        *string
-	typePostFlag    *string
-	initIndexFlag   *int
+	dataFlag         *string
+	tokenFlag        *string
+	environmentFlag  *string
+	nameFlag         *string
+	descriptionFlag  *string
+	typeContentFlag  *string
+	monthFlag        *string
+	yearFlag         *string
+	typePostFlag     *string
+	initIndexFlag    *int
+	articlesJSONFlag *string
 )
 
 func main() {
@@ -39,7 +41,8 @@ func main() {
 	monthFlag = flag.String("month", "01", "Month to bring Articles. Default: 01")
 	yearFlag = flag.String("year", "2018", "Year to bring Articles. Default: 2018")
 	typePostFlag = flag.String("type-post", "video", "Article type to be searched. Default: video")
-	initIndexFlag = flag.Int("init-index", 1, "Index to start search Articles")
+	initIndexFlag = flag.Int("init-index", 0, "Index to start search Articles")
+	articlesJSONFlag = flag.String("jsons", "", "Migrate one element")
 
 	flag.Parse()
 
@@ -54,7 +57,17 @@ func main() {
 	}
 
 	if *typeContentFlag == "categories" || *typeContentFlag == "tags" {
-		catalogsLogic()
+		if *articlesJSONFlag != "" {
+			fmt.Println("Don't support filler from url json")
+			os.Exit(0)
+		}
+	}
+
+	if *articlesJSONFlag != "" && *typeContentFlag == "articles" {
+		jsons := strings.Split(*articlesJSONFlag, ",")
+		if len(jsons) > 0 {
+			fillArticleFromJSON(jsons)
+		}
 	}
 
 	if *typeContentFlag == "articles" {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const appVersion = "0.0.12"
+const appVersion = "0.0.13"


### PR DESCRIPTION
# Issue
* We required to filler articles from json param.

# Solution
* Add new param; `--jsons`
* Is disabled filler with an init-index when --jsons param is used or `type` flag is `tags, categories`
* Refactor process data

# Long explanation

# Test
* Use `--jsons` params

```shell
go run *.go --data https://api.culturacolectiva.com/rest-api/apicms/v1/getArticleJson/ --type-post post --type articles --year 2018 --month 10 --jsons https://culturacolectiva.com/json/43147/,https://culturacolectiva.com/json/43148/,https://culturacolectiva.com/json/43149/ --token ${token}
```

<img width="1230" alt="captura de pantalla 2018-10-29 a la s 14 21 26" src="https://user-images.githubusercontent.com/1786721/47677891-f60d4c00-db85-11e8-93b5-dc7aed6e7e19.png">


